### PR TITLE
Remove HTTP dependencies

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,9 +2,9 @@
 <html>
     <head>
         <title>NSA Code Word Generator</title>
-        <link href='http://fonts.googleapis.com/css?family=Russo+One' rel='stylesheet' type='text/css'>
+        <link href='//fonts.googleapis.com/css?family=Russo+One' rel='stylesheet' type='text/css'>
         <script src="nsa.js"></script>
-        <script src="http://code.jquery.com/jquery-1.11.0.min.js"></script>
+        <script src="//code.jquery.com/jquery-1.11.0.min.js"></script>
         <style type="text/css">
             .align {height:100px; line-height:100px; text-align:center;}
             h1 { font-size: 500%; font-family: 'Russo One', sans-serif; }
@@ -49,4 +49,3 @@
         </script>
     </body>
 </html>
-


### PR DESCRIPTION
Modern browsers are moving away from HTTP whenever possible and will
then not accept resources loaded over HTTP when the site uses HTTPS.

This PR fixes that.


Thanks for the hilarious service!
//@Carlgo11